### PR TITLE
updating AUTHORS and p_kernel

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Saager Mhatre <saager.mhatre@gmail.com>
 Iain Douglas <centos@1n6.org.uk>
 Anssi Johansson <centos@miuku.net>
 Matej Habrnal <mhabrnal@redhat.com>
+Akemi Yagi <amyagi@gmail.com>

--- a/tests/p_kernel/kernel_centos_keyring.sh
+++ b/tests/p_kernel/kernel_centos_keyring.sh
@@ -8,7 +8,7 @@ if [ "$centos_ver" = "7" ] ; then
   for id in kpatch "Driver update" kernel
   do
     t_Log "Verifying x.509 CentOS ${id}"
-    grep -i "CentOS Linux ${id} signing key" /var/log/dmesg > /dev/null 2>&1
+    keyctl list %:.system_keyring | grep -i "CentOS Linux ${id} signing key" > /dev/null 2>&1
     t_CheckExitStatus $?
   done
 else


### PR DESCRIPTION
In kernel_centos_keyring.sh, use the keyctl command that verifies and shows the keys on the system key ring instead of parsing /var/log/dmesg (el7 only).
