### PR TITLE
fix(p_samba): mimic 'security = share' (deprecated) in the test config

### DIFF
--- a/tests/p_samba/samba_share_test.sh
+++ b/tests/p_samba/samba_share_test.sh
@@ -13,7 +13,8 @@ cat > /etc/samba/smb.conf <<EOF
 [global] 
 workgroup = wrkgrp 
 netbios name = smbsrv 
-security = share  
+security = user
+map to guest = Bad User
 
 [testshare]
 comment = Test share


### PR DESCRIPTION
'security = share' was deprecated in previous versions and removed in
the version shipped with CentOS 7-1511. We can mimic the same behavior with
'security = user' and setting a 'map to guest' directive

Tested on: CentOS 5, CentOS 7-1503, and CentOS 7-1503 + 7-1511qa
