### PR TITLE
Fix which_basic.sh test

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Iain Douglas <centos@1n6.org.uk>
 Anssi Johansson <centos@miuku.net>
 Matej Habrnal <mhabrnal@redhat.com>
 Akemi Yagi <amyagi@gmail.com>
+Alex Baranowski <aleksander.baranowski@yahoo.pl>

--- a/tests/p_which/which_basic.sh
+++ b/tests/p_which/which_basic.sh
@@ -2,5 +2,7 @@
 # Author: Alice Kaerast <alice@kaerast.info>
 
 t_Log "Running $0 - Checking which can find itself"
-/usr/bin/which which | grep -q "/usr/bin/which"
+# which package provides /usr/bin/which and /bin/which 
+# so results are depending on PATH variable
+/usr/bin/which which | grep -E -q "/usr/bin/which|/bin/which"
 t_CheckExitStatus $?


### PR DESCRIPTION
The PoC
```
vagrant init centos/7
vagrant up --provider libvirt; # you can choose different provider
vagrant ssh -- -A # Everything down below is inside VM
git clone git@github.com:CentOS/sig-core-t_functional.git
cd sig-core-t_functional/
sudo ./runtests.sh p_which
```
Will return failed result
[+] Mon Oct  8 15:23:46 UTC 2018 -> Running ./tests/p_which/which_basic.sh - Checking which can find itself
[+] Mon Oct  8 15:23:46 UTC 2018 -> FAIL

After patching it with sed

```
sed -i  "s/grep -q \"\/usr\/bin\/which\"/grep -E -q \"\/usr\/bin\/which|\/bin\/which\"/" ./tests/p_which/which_basic.sh
sudo ./runtests.sh p_which
```
everything works.