### PR TITLE
Enable tests on el7

### DIFF
--- a/tests/p_mod_wsgi/0-install_mod_wsgi.sh
+++ b/tests/p_mod_wsgi/0-install_mod_wsgi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
-if (t_GetPkgRel basesystem | grep -q el6)
+if [ $centos_ver -ge 6 ]
 then
     t_InstallPackage mod_wsgi
     service httpd restart

--- a/tests/p_mod_wsgi/mod_wsgi_test.sh
+++ b/tests/p_mod_wsgi/mod_wsgi_test.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 t_Log "Running $0 - Apache httpd mod_wsgi is functional"
-if (t_GetPkgRel basesystem | grep -q el6); then
+if [ $centos_ver -ge 6 ]
+then
 	while [ `ps fax | grep 'sbin/httpd' | grep -v grep  | wc -l` -gt 0 ]; do
       #t_ServiceControl httpd stop
       killall -s KILL httpd

--- a/tests/p_rrdtool/0-install_rrdtool.sh
+++ b/tests/p_rrdtool/0-install_rrdtool.sh
@@ -2,7 +2,7 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 #         Athmane Madjoudj <athmanem@gmail.com>
 
-if (t_GetPkgRel basesystem | grep -q el6)
+if [ $centos_ver -ge 6 ]
 then
     # Install rrdtool
     t_InstallPackage rrdtool

--- a/tests/p_rrdtool/rrdtool_test.sh
+++ b/tests/p_rrdtool/rrdtool_test.sh
@@ -3,7 +3,7 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 # RRD-sample from http://oss.oetiker.ch/rrdtool/doc/rrdcreate.en.html
 
-if (t_GetPkgRel basesystem | grep -q el6)
+if [ $centos_ver -ge 6 ]
 then
     t_Log "Running $0 - rrdtool: create rrd, write values and retrieve values test."
 


### PR DESCRIPTION
Current version check logic checks system is el6 or not. However it would be nice to run tests on el7 so that I have changed version check lines.