### PR TITLE
Add sosreport tests

### DIFF
--- a/tests/p_sosreport/0-install_sos.sh
+++ b/tests/p_sosreport/0-install_sos.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Author: Alex Baranowski (aleksander.baranowski@yahoo.pl)
+
+t_Log "$0 - installing sos package"
+t_InstallPackage sos

--- a/tests/p_sosreport/t-01_test_can_invoke_sos.sh
+++ b/tests/p_sosreport/t-01_test_can_invoke_sos.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Author: Alex Baranowski <aleksander dot baranowski at yahoo.pl>
+
+# This is the most basic test that checks if the sosreport can load.
+# When sosreport list its plugin it has to load the policy (CentOS patch that).
+# If the patch breaks policy, it's likely that it won't produce any meaningful output.
+
+t_Log "$0 tests for policy loading"
+sosreport -l  > /dev/null 2>&1
+t_CheckExitStatus $?

--- a/tests/p_sosreport/t-02_can_make_sosreport.sh
+++ b/tests/p_sosreport/t-02_can_make_sosreport.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Author: Alex Baranowski <aleksander dot baranowski at yahoo.pl>
+# This test makes sosreport. Then check if the sosreport file is bigger than 1MiB.
+
+t_Log "Running $0"
+export MY_ID="${RANDOM}-$$"
+export MINIMAL_SIZE=1048576 # 1MiB
+
+cleanup(){
+  t_Log "Removing the sosreport files"
+  rm -f /tmp/sosreport*${MY_ID}*tar*  >/dev/null
+  rm -f /var/tmp/sosreport*${MY_ID}*tar*  >/dev/null
+}
+
+t_Log "$0 tests sosreport generaton"
+
+tests(){
+  yes "$MY_ID" | sosreport 
+  # shellcheck disable=SC2086
+  SOS_SIZE=$(stat -c "%s" $1/sosreport*${MY_ID}*tar.xz)
+  t_Log "Check for minimal size of generated sosreport"
+  [ "$SOS_SIZE" -gt "$MINIMAL_SIZE" ]
+  t_checkExitStatus $?
+}
+
+if [ "$centos_ver" -gt 6 ]; then 
+  tests "/var/tmp"
+else 
+  tests "/tmp"
+fi
+cleanup

--- a/tests/p_sosreport/t-03_test_sosreport_branding.sh
+++ b/tests/p_sosreport/t-03_test_sosreport_branding.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+export SOS_REPORT_LOG="/tmp/sos-report-test.log"
+export DISTRONAME="CentOS"
+export SUPPORT_URL="https://wiki.centos.org/"
+
+t_Log "$0 dupa"
+
+cleanup(){
+  t_Log "Removing the sosreport files"
+  rm -f /tmp/sosreport*${MY_ID}*tar*  >/dev/null
+  rm -f /var/tmp/sosreport*${MY_ID}*tar*  >/dev/null
+  rm -f $SOS_REPORT_LOG
+}
+
+tests_el6(){
+  t_Log "$0 Running sos branding tests for CentOS 6"
+  MY_ID="${RANDOM}-$$"
+  yes "$MY_ID"| sosreport  | tee  $SOS_REPORT_LOG
+  # CentOS 6 has redhat url :((.
+  grep -qvi 'red hat' $SOS_REPORT_LOG 
+  t_CheckExitStatus $?
+  grep -qi $DISTRONAME $SOS_REPORT_LOG 
+  t_CheckExitStatus $?
+}
+
+tests_el7_plus(){
+  t_Log "$0 Running sos branding tests for CentOS 7+"
+  MY_ID="${RANDOM}-$$"
+  yes "$MY_ID"| sosreport  | tee  $SOS_REPORT_LOG
+  # CentOS 7 has fully patched sos branding.
+  grep -qvi 'red hat' $SOS_REPORT_LOG
+  t_CheckExitStatus $?
+  grep -qvi 'redhat' $SOS_REPORT_LOG
+  t_CheckExitStatus $?
+  grep -qi $DISTRONAME $SOS_REPORT_LOG
+  t_CheckExitStatus $?
+  grep -qi $SUPPORT_URL $SOS_REPORT_LOG
+  t_CheckExitStatus $?
+}
+
+if [ "$centos_ver" -gt 6 ]; then 
+  tests_el7_plus /var/tmp
+else # EL6
+  tests_el6 /tmp
+fi
+cleanup

--- a/tests/p_sosreport/zzz-uninstall_sos.sh
+++ b/tests/p_sosreport/zzz-uninstall_sos.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+t_Log "$0 Remove sos package"
+yum remove -y sos >/dev/null 2>&1
+t_Log "$0 Remove all sos.* temporary directories"
+rm -rf  /tmp/sos.*  >/dev/null
+rm -rf /var/tmp/sos.*  >/dev/null
+
+
+
+


### PR DESCRIPTION
Hi,

sos is package patched by CentOS; this PR adds tests that check the `sosreport` command.
There are the following tests:
1. Can list plugins
2. Generate full sosreport && checks its size (at least1MiB)
3. Generate full sosreport && checks the branding strings.

Note that sos in C6 is not branded properly, so test (3) for C6 is less strict.

I tested in at C6 and C7 VMs.

Bests,
Alex