### PR TITLE
Fix passwd tests for machines where sssd is installed

### DIFF
--- a/tests/p_passwd/_user_password.expect
+++ b/tests/p_passwd/_user_password.expect
@@ -6,19 +6,29 @@ match_max 6000
 spawn su passtest -c passwd
 expect  -re "(UNIX|Current) password:" { send -- "passtest\r" }
 expect { 
-         "You must wait longer to change your password" 
-             {
-              exit 2 
-             }
-         "Authentication token manipulation error"
-             {
-              exit 3
-             }
-         "password:" 
-             {
-              send -- "ano24ther\r"
-              expect "*?password:*"
-              send -- "ano24ther\r"
-              expect eof 
-             }
-       }
+	 "You must wait longer to change your password" 
+	     {
+	      exit 2 
+	     }
+	 "Authentication token manipulation error"
+	     {
+	      exit 3
+	     }
+	 "Current Password:" { 
+	      send -- "passtest\r"    
+              expect {
+		"Authentication token manipulation error"
+	        {
+	         exit 3
+	        }
+	     }
+	 }
+	 "password:" 
+	     {
+	      send -- "ano24ther\r"
+	      expect "*?\[pP]assword:*"
+	      send -- "ano24ther\r"
+	      expect eof 
+	     }
+}
+


### PR DESCRIPTION
When sssd is installed, there is a second prompt after entering an
invalid password. Since we check for this, we need to have an entry
in that case, we should expect another 'Current Password:' prompt,
provide the invalid password again, and then re-expect a token error

references: https://bugzilla.redhat.com/show_bug.cgi?id=1659100