### PR TITLE
tests/p_annobin: Specify the language to the compiler

### DIFF
--- a/tests/p_annobin/10-test_annobin-gcc.sh
+++ b/tests/p_annobin/10-test_annobin-gcc.sh
@@ -12,7 +12,7 @@ t_Log "Running $0 - build a hello world program with gcc using annobin"
 
 BUILTPROG=$(mktemp)
 
-cat <<EOF | gcc -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -o ${BUILTPROG} -
+cat <<EOF | gcc -x c -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -o ${BUILTPROG} -
 #include <stdio.h>
 int main() {
 	printf("Hello World!\n");

--- a/tests/p_annobin/20-test_annobin-gcc-c++.sh
+++ b/tests/p_annobin/20-test_annobin-gcc-c++.sh
@@ -12,7 +12,7 @@ t_Log "Running $0 - build a hello world program with gcc-c++ using annobin"
 
 BUILTPROG=$(mktemp)
 
-cat <<EOF | g++ -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -o ${BUILTPROG} -
+cat <<EOF | g++ -x c++ -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -o ${BUILTPROG} -
 #include <iostream>
 int main() {
 	std::cout << "Hello World!\n";


### PR DESCRIPTION
Since we are feeding code to gcc through standard input, it cannot
determine the language via the file extension. Thus, we explicitly
tell GCC which langauges we are compiling for.