### PR TITLE
Correctly skip mod_wsgi tests as needed

### DIFF
--- a/tests/p_mod_wsgi/10-test_mod_wsgi.sh
+++ b/tests/p_mod_wsgi/10-test_mod_wsgi.sh
@@ -2,8 +2,8 @@
 
 t_Log "Running $0 - Apache httpd mod_wsgi is functional"
 
-if [[ $centos_ver -lt 6 ]]; then
-    t_Log "mod_wsgi doesn't exist before CentOS 6 -> SKIP"
+if [[ $centos_ver -lt 6 || $centos_ver -gt 7 ]]; then
+    t_Log "mod_wsgi not available before CentOS 6 or after CentOS 7 -> SKIP"
     exit 0
 fi
 

--- a/tests/p_python3-mod_wsgi/10-test_python3-mod_wsgi.sh
+++ b/tests/p_python3-mod_wsgi/10-test_python3-mod_wsgi.sh
@@ -1,1 +1,33 @@
-../p_mod_wsgi/10-test_mod_wsgi.sh
+#!/bin/bash
+
+t_Log "Running $0 - Apache httpd python3-mod_wsgi is functional"
+
+if [[ $centos_ver -lt 8 ]]; then
+    t_Log "python3-mod_wsgi doesn't exist before CentOS 8 -> SKIP"
+    exit 0
+fi
+
+cat > /etc/httpd/conf.d/tfapp.conf << EOF
+WSGIScriptAlias /tfapp /var/www/html/tfapp.wsgi
+EOF
+
+cat > /var/www/html/tfapp.wsgi << EOF
+def application(environ, start_response):
+    status = '200 OK'
+    output = 't_functional_mod_wsgi_test'.encode()
+    response_headers = [
+        ('Content-type', 'text/plain'),
+        ('Content-Length', str(len(output)))
+    ]
+    start_response(status, response_headers)
+    return [output]
+EOF
+
+systemctl restart httpd
+
+curl -s http://localhost/tfapp | grep -q 't_functional_mod_wsgi_test'
+t_CheckExitStatus $?
+
+systemctl stop httpd
+
+rm /etc/httpd/conf.d/tfapp.conf /var/www/html/tfapp.wsgi

--- a/tests/p_python38-mod_wsgi/10-test_python38-mod_wsgi.sh
+++ b/tests/p_python38-mod_wsgi/10-test_python38-mod_wsgi.sh
@@ -1,1 +1,33 @@
-../p_mod_wsgi/10-test_mod_wsgi.sh
+#!/bin/bash
+
+t_Log "Running $0 - Apache httpd python38-mod_wsgi is functional"
+
+if [[ $centos_ver -lt 8 ]]; then
+    t_Log "python38-mod_wsgi doesn't exist before CentOS 8 -> SKIP"
+    exit 0
+fi
+
+cat > /etc/httpd/conf.d/tfapp.conf << EOF
+WSGIScriptAlias /tfapp /var/www/html/tfapp.wsgi
+EOF
+
+cat > /var/www/html/tfapp.wsgi << EOF
+def application(environ, start_response):
+    status = '200 OK'
+    output = 't_functional_mod_wsgi_test'.encode()
+    response_headers = [
+        ('Content-type', 'text/plain'),
+        ('Content-Length', str(len(output)))
+    ]
+    start_response(status, response_headers)
+    return [output]
+EOF
+
+systemctl restart httpd
+
+curl -s http://localhost/tfapp | grep -q 't_functional_mod_wsgi_test'
+t_CheckExitStatus $?
+
+systemctl stop httpd
+
+rm /etc/httpd/conf.d/tfapp.conf /var/www/html/tfapp.wsgi


### PR DESCRIPTION
Previously in #55 I tried to share the same test script between the three mod_wsgi tests, but that doesn't work with the skip conditions.