### PR TITLE
Only run python38-mod_wsgi on CentOS Stream

### DIFF
--- a/tests/0_lib/functions.sh
+++ b/tests/0_lib/functions.sh
@@ -102,6 +102,14 @@ function t_DistCheck
 # Additionally set distro release to $centos_ver
 centos_ver=$(t_DistCheck)
 
+# Description: test if we are using CentOS Stream
+function t_StreamCheck
+{
+    rpm -q centos-release-stream &> /dev/null && echo "yes" || echo "no"
+}
+# set stream variable
+centos_stream=$(t_StreamCheck)
+
 # Description: Get a package (rpm) version number
 function t_GetPkgVer
 {
@@ -170,4 +178,5 @@ export -f t_Assert
 export -f t_Assert_Equals
 export -f t_Select_Alternative
 export centos_ver
+export centos_stream
 export arch

--- a/tests/p_python38-mod_wsgi/0-install_python38-mod_wsgi.sh
+++ b/tests/p_python38-mod_wsgi/0-install_python38-mod_wsgi.sh
@@ -7,4 +7,10 @@ if [[ $centos_ver -lt 8 ]]; then
     exit 0
 fi
 
+# TODO: remove after 8.2 rebuild
+if [[ $centos_stream == "no" ]]; then
+    t_Log "python38-mod_wsgi is only in CentOS Stream -> SKIP"
+    exit 0
+fi
+
 t_InstallPackage python38-mod_wsgi

--- a/tests/p_python38-mod_wsgi/10-test_python38-mod_wsgi.sh
+++ b/tests/p_python38-mod_wsgi/10-test_python38-mod_wsgi.sh
@@ -7,6 +7,12 @@ if [[ $centos_ver -lt 8 ]]; then
     exit 0
 fi
 
+# TODO: remove after 8.2 rebuild
+if [[ $centos_stream == "no" ]]; then
+    t_Log "python38-mod_wsgi is only in CentOS Stream -> SKIP"
+    exit 0
+fi
+
 cat > /etc/httpd/conf.d/tfapp.conf << EOF
 WSGIScriptAlias /tfapp /var/www/html/tfapp.wsgi
 EOF

--- a/tests/p_python38-mod_wsgi/20-remove_python38-mod_wsgi.sh
+++ b/tests/p_python38-mod_wsgi/20-remove_python38-mod_wsgi.sh
@@ -7,4 +7,10 @@ if [[ $centos_ver -lt 8 ]]; then
     exit 0
 fi
 
+# TODO: remove after 8.2 rebuild
+if [[ $centos_stream == "no" ]]; then
+    t_Log "python38-mod_wsgi is only in CentOS Stream -> SKIP"
+    exit 0
+fi
+
 t_RemovePackage python38-mod_wsgi


### PR DESCRIPTION
In #55 I added a python38-mod_wsgi test, but currently that package only exists in CentOS Stream.