### PR TITLE
Fix for hosts with more than one IP and/or IPv6

### DIFF
--- a/tests/p_iputils/tracepath_test.sh
+++ b/tests/p_iputils/tracepath_test.sh
@@ -12,16 +12,16 @@ fi
 
 t_Log "Running $0 - running ${TEST} to ${HOST}"
 
-IP=$(host ${HOST})
+IP=$(dig +short ${HOST} A ${HOST} AAAA)
 FILE=/var/tmp/tracepath_result
 ret_val=1
 # getting IP-address of default gateway as a fall back
 defgw=$(ip route list | grep default | cut -d' ' -f3)
 
-if [[ $IP =~ .*address\ ([0-9.]*) ]]
+if [[ ! -z "$IP" ]]
 then
   tracepath -n ${HOST} > ${FILE}
-  COUNT=$(grep -c ${BASH_REMATCH[1]} ${FILE})
+  COUNT=$(echo "$IP" | grep -cf - ${FILE})
   TTL=$(grep -c 'Too many hops' ${FILE})
   GW=$(grep -c ${defgw} ${FILE})
   if ([ $COUNT = 1 ] || [ $COUNT = 2 ])

--- a/tests/p_mtr/mtr_test.sh
+++ b/tests/p_mtr/mtr_test.sh
@@ -12,13 +12,13 @@ fi
 
 t_Log "Running $0 - running ${TEST} to ${HOST}"
 ret_val=1
+FILE=/var/tmp/mtr_result
 
-IP=$(host ${HOST})
+IP=$(dig +short ${HOST} A ${HOST} AAAA)
 
-regex='.*address\ ([0-9.]*)'
-if [[ $IP =~ $regex ]]
+if [[ ! -z "$IP" ]]
 then
-  COUNT=$( mtr -nr -c1 ${HOST} | grep -c ${BASH_REMATCH[1]} )
+  COUNT=$(echo "$IP" | grep -cf - ${FILE})
   if [ $COUNT = 1 ]
   then
     t_Log "${TEST} reached ${HOST}"
@@ -29,4 +29,5 @@ then
   fi
 fi
 
+/bin/rm ${FILE}
 t_CheckExitStatus $ret_val

--- a/tests/p_traceroute/traceroute_test.sh
+++ b/tests/p_traceroute/traceroute_test.sh
@@ -12,16 +12,16 @@ fi
 
 t_Log "Running $0 - running ${TEST} to ${HOST}"
 
-IP=$(host ${HOST})
+IP=$(dig +short ${HOST} A ${HOST} AAAA)
 FILE=/var/tmp/traceroute_result
 ret_val=1
 # getting IP-address of default gateway as a fall back
 defgw=$(ip route list | grep default | cut -d' ' -f3)
 
-if [[ $IP =~ .*address\ ([0-9.]*) ]]
+if [[ ! -z "$IP" ]]
 then
   traceroute -n ${HOST} > ${FILE}
-  COUNT=$(grep -c ${BASH_REMATCH[1]} ${FILE})
+  COUNT=$(echo "$IP" | grep -cf - ${FILE})
   TTL=$(egrep -c '30  \* \* \*' ${FILE})
   GW=$(grep -c ${defgw} ${FILE})
   if [ $COUNT = 2 ]


### PR DESCRIPTION
We wanted to be able to change the targets of these tests, but we discovered the tests don't work well for hosts that have more than one IP address or use IPv6. This PR fixes that to make these tests more flexible.