### PR TITLE
Look for any png file

### DIFF
--- a/tests/p_file/02_file_mime_image.sh
+++ b/tests/p_file/02_file_mime_image.sh
@@ -5,14 +5,7 @@
 
 t_Log "Running $0 - checking if file can recognize image mime file type "
 
-case $centos_ver in
-  5|6)
-    pngfile=/usr/lib/anaconda-runtime/boot/syslinux-splash.png
-    ;;
-  *)
-    pngfile=/usr/share/anaconda/boot/syslinux-splash.png
-    ;;
-esac
+pngfile="$(find /usr/share/ -name '*.png' -print -quit)"
 
 file $pngfile -i | grep -q 'image/png'
 


### PR DESCRIPTION
The CentOS 8 tests are broken since Anaconda was excluded because this test relies on a file installed by that package. This fixes that so we just check any png file, not a specific one that may disappear at some point.