### PR TITLE
We may not have any png files at all

### DIFF
--- a/tests/p_file/02_file_mime_image.sh
+++ b/tests/p_file/02_file_mime_image.sh
@@ -7,6 +7,11 @@ t_Log "Running $0 - checking if file can recognize image mime file type "
 
 pngfile="$(find /usr/share/ -name '*.png' -print -quit)"
 
+if [ -z "$pngfile" ];then
+    t_Log "No png file found => SKIP"
+    exit 0
+fi
+
 file $pngfile -i | grep -q 'image/png'
 
 t_CheckExitStatus $?


### PR DESCRIPTION
This fails while testing our C8 docker images because there are no RPMs installed with png files.