### PR TITLE
Only check for REDHAT_SUPPORT_PRODUCT and REDHAT_SUPPORT_PRODUCT_VERSION on EL7

### DIFF
--- a/tests/p_centos-release/centos-release_os-release.sh
+++ b/tests/p_centos-release/centos-release_os-release.sh
@@ -5,7 +5,7 @@ t_Log "Running $0 - /etc/os-release has correct ABRT string for CentOS $centos_v
 
 if [ "$centos_ver" -ge 7 ];then
 	if [[ $centos_stream == "no" ]]; then
-	  for string in CENTOS_MANTISBT_PROJECT=\"CentOS-$centos_ver\" CENTOS_MANTISBT_PROJECT_VERSION=\"$centos_ver\" REDHAT_SUPPORT_PRODUCT=\"centos\" REDHAT_SUPPORT_PRODUCT_VERSION=\"$centos_ver\"
+	  for string in CENTOS_MANTISBT_PROJECT=\"CentOS-$centos_ver\" CENTOS_MANTISBT_PROJECT_VERSION=\"$centos_ver\"
 	  do 
 	    grep -q $string /etc/os-release
 	    if [ $? -ne "0" ];then
@@ -15,6 +15,17 @@ if [ "$centos_ver" -ge 7 ];then
 	  done  
 	else
 	  echo "Skipping for CentOS Stream" ; exit 0
+	fi
+
+	if [ "$centos_ver" -eq 7 ]; then
+	  for string in REDHAT_SUPPORT_PRODUCT=\"centos\" REDHAT_SUPPORT_PRODUCT_VERSION=\"$centos_ver\"
+	  do 
+	    grep -q $string /etc/os-release
+	    if [ $? -ne "0" ];then
+	      t_Log "missing string $string in os-release file !"
+	      exit 1
+	    fi
+	  done  
 	fi
 else
   echo "Skipping for CentOS 5 and 6 ..." ; exit 0


### PR DESCRIPTION
We removed these fields in CentOS Linux 8

Signed-off-by: Brian Stinson <bstinson@centosproject.org>