### PR TITLE
nc option -i/-d is unnecessary

### DIFF
--- a/tests/p_dovecot/dovecot_imap_login.sh
+++ b/tests/p_dovecot/dovecot_imap_login.sh
@@ -7,22 +7,14 @@ t_Log "Running $0 - adding imaptest local user account + attempting IMAP login"
 { userdel -rf imaptest; useradd imaptest && echo imaptest | passwd --stdin imaptest; } &>/dev/null
 
 # creating maildir in HOME, else test will fail at first try
-mkdir -m 700 -p /home/imaptest/mail/.imap/INBOX 
+mkdir -m 700 -p /home/imaptest/mail/.imap/INBOX
 chown -R imaptest:imaptest /home/imaptest/mail
 
 ret_val=1
 
 t_Log "Dovecot IMAP login test"
 
-# EL7 comes with nmap-nc , different from nc so different options to use
-
-if [ "$centos_ver" -ge 7 ];then
- nc_options="-d 3 -w 5"
-else
- nc_options="-i 3 -w 5"
-fi
-
-echo -e "01 LOGIN imaptest imaptest\n" | nc ${nc_options} localhost 143 | grep -q "Logged in."
+echo -e "01 LOGIN imaptest imaptest\n" | nc -w 5 localhost 143 | grep -q "Logged in."
 
 ret_val=$?
 

--- a/tests/p_dovecot/dovecot_pop3_login.sh
+++ b/tests/p_dovecot/dovecot_pop3_login.sh
@@ -7,20 +7,12 @@ t_Log "Running $0 - adding pop3test local user account + attempting POP3 login"
 { userdel -rf pop3test; useradd pop3test && echo pop3test | passwd --stdin pop3test; } &>/dev/null
 
 # creating maildir in HOME, else test will fail at first try
-mkdir -m 700 -p /home/pop3test/mail/.imap/INBOX 
+mkdir -m 700 -p /home/pop3test/mail/.imap/INBOX
 chown -R pop3test:pop3test /home/pop3test/mail/.imap/INBOX
 
 t_Log "Dovecot POP3 login test"
-# EL7 comes with nmap-nc , different from nc so different options to use
 
-if [ "$centos_ver" -ge 7 ];then
- nc_options="-d 3 -w 5"
-else
- nc_options="-i 3 -w 5"
-fi
-
-
-echo -e "user pop3test\npass pop3test\n" | nc ${nc_options} localhost 110 | grep -q "+OK Logged in."
+echo -e "user pop3test\npass pop3test\n" | nc -w 5 localhost 110 | grep -q "+OK Logged in."
 
 t_CheckExitStatus $?
 


### PR DESCRIPTION
This test fails on a C8/CS8 system with EPEL configured because you have `netcat` instead of `nmap-ncat`. In any case, there's no need to make the code more complicated than it needs to be, the `-i/-d` options is not necessary.