### PR TITLE
Basic test of dhcp installability

### DIFF
--- a/tests/p_dhcp/0-install_dhcp.sh
+++ b/tests/p_dhcp/0-install_dhcp.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Author: Petr Menšík <pemensik@redhat.com>
+
+t_InstallPackage dhcp-client

--- a/tests/p_dhcp/bind_test.sh
+++ b/tests/p_dhcp/bind_test.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Author: Petr Menšík <pemensik@redhat.com>
+
+t_Log "Running $0 - dhcp-client: can upgrade client"
+
+dnf upgrade --assumeno 'bind*' 'dhcp*'
+
+t_CheckExitStatus $?


### PR DESCRIPTION
Recent failure of dhcp rebuild were not catched by tests. Ensure dhcp
and bind both can be upgraded to latest version. Does not install them,
just checks dependencies.