### PR TITLE
Container flags

### DIFF
--- a/.github/workflows/centos-stream8-container-on-ubuntu.yml
+++ b/.github/workflows/centos-stream8-container-on-ubuntu.yml
@@ -1,0 +1,91 @@
+jobs:
+  test_0:
+    name: test_0
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+      - run: pip install each
+      - run: ls -x1 tests | grep "^0_" > testlist
+      - run: docker build --build-arg CONTAINERTEST=1 -f Container-8.test -t centos_stream_8_sigt_f . 
+      - run: "docker run -d --name test8 --privileged --rm -e CONTAINERTEST=1 --volume /sys/fs/cgroup:/sys/fs/cgroup:ro -v `pwd`:/opt centos_stream_8_sigt_f"
+      - run: each -j 4 --no-stdin testlist "docker exec --privileged -e CONTAINERTEST=1  test8 sh -c 'cd /opt && ./runtests.sh {}'"
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \;
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \; > failed_tests
+      - run: cat failed_tests | grep -v "^1" | xargs -i tail {}/out
+      - run: "! [[ -s failed_tests ]]"
+  test_pxaa:
+    name: test_pxaa
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+      - run: pip install each
+      - run: ls -x1 tests | grep "^p_" > testlist
+      - run: split -l45 testlist
+      - run: docker build --build-arg CONTAINERTEST=1 -f Container-8.test -t centos_stream_8_sigt_f . 
+      - run: "docker run -d --name test8 --privileged --rm -e CONTAINERTEST=1 --volume /sys/fs/cgroup:/sys/fs/cgroup:ro -v `pwd`:/opt centos_stream_8_sigt_f"
+      - run: each -j 4 --no-stdin xaa "docker exec --privileged -e CONTAINERTEST=1  test8 sh -c 'cd /opt && ./runtests.sh {}'"
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \;
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \; > failed_tests
+      - run: cat failed_tests | grep -v "^1" | xargs -i tail {}/out
+      - run: "! [[ -s failed_tests ]]"
+  test_pxab:
+    name: test_pxab
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+      - run: pip install each
+      - run: ls -x1 tests | grep "^p_" > testlist
+      - run: split -l45 testlist
+      - run: docker build --build-arg CONTAINERTEST=1 -f Container-8.test -t centos_stream_8_sigt_f . 
+      - run: "docker run -d --name test8 --privileged --rm -e CONTAINERTEST=1 --volume /sys/fs/cgroup:/sys/fs/cgroup:ro -v `pwd`:/opt centos_stream_8_sigt_f"
+      - run: each -j 4 --no-stdin xab "docker exec --privileged -e CONTAINERTEST=1  test8 sh -c 'cd /opt && ./runtests.sh {}'"
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \;
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \; > failed_tests
+      - run: cat failed_tests | grep -v "^1" | xargs -i tail {}/out
+      - run: "! [[ -s failed_tests ]]"
+  test_pxac:
+    name: test_pxac
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+      - run: pip install each
+      - run: ls -x1 tests | grep "^p_" > testlist
+      - run: split -l45 testlist
+      - run: docker build --build-arg CONTAINERTEST=1 -f Container-8.test -t centos_stream_8_sigt_f . 
+      - run: "docker run -d --name test8 --privileged --rm -e CONTAINERTEST=1 --volume /sys/fs/cgroup:/sys/fs/cgroup:ro -v `pwd`:/opt centos_stream_8_sigt_f"
+      - run: each -j 4 --no-stdin xac "docker exec --privileged -e CONTAINERTEST=1  test8 sh -c 'cd /opt && ./runtests.sh {}'"
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \;
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \; > failed_tests
+      - run: cat failed_tests | grep -v "^1" | xargs -i tail {}/out
+      - run: "! [[ -s failed_tests ]]"
+  test_r:
+    name: test_r
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+      - run: pip install each
+      - run: ls -x1 tests | grep "^r_" > testlist
+      - run: docker build --build-arg CONTAINERTEST=1 -f Container-8.test -t centos_stream_8_sigt_f . 
+      - run: "docker run -d --name test8 --privileged --rm -e CONTAINERTEST=1 --volume /sys/fs/cgroup:/sys/fs/cgroup:ro -v `pwd`:/opt centos_stream_8_sigt_f"
+      - run: each -j 4 --no-stdin testlist "docker exec --privileged -e CONTAINERTEST=1  test8 sh -c 'cd /opt && ./runtests.sh {}'"
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \;
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \; > failed_tests
+      - run: cat failed_tests | grep -v "^1" | xargs -i tail {}/out
+      - run: "! [[ -s failed_tests ]]"
+  test_z:
+    name: test_z
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "actions/checkout@v2"
+      - run: pip install each
+      - run: ls -x1 tests | grep "^z_" > testlist
+      - run: docker build --build-arg CONTAINERTEST=1 -f Container-8.test -t centos_stream_8_sigt_f . 
+      - run: "docker run -d --name test8 --privileged --rm -e CONTAINERTEST=1 --volume /sys/fs/cgroup:/sys/fs/cgroup:ro -v `pwd`:/opt centos_stream_8_sigt_f"
+      - run: each -j 4 --no-stdin testlist "docker exec --privileged -e CONTAINERTEST=1  test8 sh -c 'cd /opt && ./runtests.sh {}'"
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \;
+      - run: find . -type f -name "status" -exec grep '1' "{}" \; -exec dirname "{}" \; > failed_tests
+      - run: cat failed_tests | grep -v "^1" | xargs -i tail {}/out
+      - run: "! [[ -s failed_tests ]]"  
+name: Greeting
+on:
+  push: {}

--- a/Container-8.test
+++ b/Container-8.test
@@ -1,0 +1,19 @@
+FROM quay.io/centos/centos:stream8
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]
+
+COPY . /tmp/test
+WORKDIR /tmp/test
+RUN CONTAINERTEST=1 ./runtests.sh 0_common
+RUN dnf -y install hostname initscripts iproute net-tools

--- a/Container-9.test
+++ b/Container-9.test
@@ -1,0 +1,19 @@
+FROM quay.io/centos/centos:stream9
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]
+
+COPY . /tmp/test
+WORKDIR /tmp/test
+RUN  CONTAINERTEST=1 ./runtests.sh 0_common
+RUN dnf -y install hostname initscripts iproute net-tools

--- a/tests/0_common/00_centos_repos.sh
+++ b/tests/0_common/00_centos_repos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$centos_ver" -eq "8" ]; then
+if [ "$centos_ver" -ge "8" ]; then
   t_Log "python not installed by default on .el8. SKIP"
   exit 0
 else

--- a/tests/0_common/50_test_comps.sh
+++ b/tests/0_common/50_test_comps.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - testing comps.xml groups"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if [ "$centos_ver" -eq "7" ]; then
     t_Log "CentOS $centos_ver -> SKIP"
     exit 0
@@ -13,14 +18,13 @@ ALL_GROUPS=`dnf group list -v --hidden | grep '^   ' | sed 's/.*(\(.*\))$/\1/'`
 
 for GROUP in $ALL_GROUPS; do
     t_Log " - testing group $GROUP"
-
     # Pretend to install the group, but all we really want is the solver debug data
-    dnf --installroot=/tmp group --releasever $centos_ver install --assumeno --debugsolver $GROUP >/dev/null
-
+    dnf --installroot=/tmp group --releasever $centos_ver install --assumeno --debugsolver $GROUP
+    pwd
+    ls
     # Check the solver results to see if there are problems
-    grep -qw '^problem' debugdata/rpms/solver.result
+    grep '^problem' debugdata/rpms/solver.result
     RES=$?
-
     # Clean up the debugdata
     rm -rf debugdata/
 

--- a/tests/0_lib/functions.sh
+++ b/tests/0_lib/functions.sh
@@ -22,6 +22,10 @@ function t_CheckExitStatus
 # Arguments: a space separated list of package names to install.
 function t_InstallPackage
 {
+    if [ "$centos_ver" -ge "8" ]; then
+        mkdir /var/cache/{dnf,yum,system-upgrade}
+        dnf makecache
+    fi
 	t_Log "Attempting yum install: $*"
 	/usr/bin/yum -y -d${YUMDEBUG} install "$@"
   # TODO: add a hook here, to make sure all binary files have ldd run
@@ -70,15 +74,15 @@ function t_ResetModule
 function t_Process
 {
 	exec 7< $@
-	
+
 	while read -u 7 f
 	do
 		# skip files named readme or those that start with an _
 		[[ "$(basename ${f})" =~ readme|^_ ]] &&  continue;
-		
+
 		# handy tip: chmod -x to disable individual test scripts.
 		[ -x ${f} ] && ${f}
-			
+
 	done
 
 	return 0
@@ -90,14 +94,14 @@ function t_Process
 function t_CheckDeps
 {
 	# TODO
-	
+
 	# success, all packages are installed
 	return 0
 }
 
 # Description: perform a service control and sleep for a few seconds to let
-#   the dust settle. Using this function avoids a race condition wherein 
-#   subsequent tests execute (and typically fail) before a service has had a 
+#   the dust settle. Using this function avoids a race condition wherein
+#   subsequent tests execute (and typically fail) before a service has had a
 #   chance to fully start/open a network port etc.
 # Call it with cycle instead of start, and it will stop+start
 #   handy, if you dont know the service might already be running
@@ -118,7 +122,7 @@ function t_ServiceControl
 # Description: Get a package (rpm) release number
 function t_GetPkgRel
 {
-       rpm -q --queryformat '%{RELEASE}' $1 
+       rpm -q --queryformat '%{RELEASE}' $1
 }
 
 # Description: return the distro release (returns 5 or 6 now)
@@ -180,10 +184,10 @@ function t_SkipReleaseGreaterThan {
 # Description: Get a package (rpm) version number
 function t_GetPkgVer
 {
-       rpm -q --queryformat '%{version}' $1 
+       rpm -q --queryformat '%{version}' $1
 }
 
-# Description: get the arch 
+# Description: get the arch
 function t_GetArch
 {
 	rpm -q $(rpm -qf /etc/redhat-release) --queryformat '%{arch}\n'
@@ -214,7 +218,7 @@ function t_Assert
 
 function t_Assert_Equals
 {
- [ $1 -eq $2 ] 
+ [ $1 -eq $2 ]
  t_CheckExitStatus $?
 }
 function t_Select_Alternative

--- a/tests/p_arpwatch/10_arpwatch_test.sh
+++ b/tests/p_arpwatch/10_arpwatch_test.sh
@@ -11,6 +11,11 @@ fi
 
 t_Log "Running $0 - arpwatch on interface with default gateway"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 # arpwatch is broken in el7
 # See https://bugzilla.redhat.com/show_bug.cgi?id=1044062
 [[ $centos_ver -eq 7 ]] && { 

--- a/tests/p_audit/1_auditd_running.sh
+++ b/tests/p_audit/1_auditd_running.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
 t_Log "Running $0 -  check if auditd is running."
 
-if [ $SKIP_QA_HARNESS -eq 1 -o $CONTAINERTEST -eq 1 ]; then
+if [ "$SKIP_QA_HARNESS" -eq 1 ] | [ "$CONTAINERTEST" -eq 1 ] ; then
     echo "Skipping this test ..."
 else
     service auditd status > /dev/null 2>&1

--- a/tests/p_audit/1_auditd_running.sh
+++ b/tests/p_audit/1_auditd_running.sh
@@ -3,7 +3,7 @@
 
 t_Log "Running $0 -  check if auditd is running."
 
-if [ $SKIP_QA_HARNESS -eq 1 ]; then
+if [ $SKIP_QA_HARNESS -eq 1 -o $CONTAINERTEST -eq 1 ]; then
     echo "Skipping this test ..."
 else
     service auditd status > /dev/null 2>&1

--- a/tests/p_audit/2_auditd_generate-events.sh
+++ b/tests/p_audit/2_auditd_generate-events.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
+if [ $SKIP_QA_HARNESS -eq 1 -o $CONTAINERTEST -eq 1 ]; then
+	    echo "Skipping this test ..."
+else
 t_Log "Running $0 -  Generate some events for audit log."
 
 useradd testauditd
 userdel testauditd
 
 t_CheckExitStatus $?
+fi

--- a/tests/p_audit/3_auditd_logging.sh
+++ b/tests/p_audit/3_auditd_logging.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
-
+if [ $SKIP_QA_HARNESS -eq 1 -o $CONTAINERTEST -eq 1 ]; then
+	    echo "Skipping this test ..."
+else
 t_Log "Running $0 -  check if audit log is not empty."
 
 [[ -s /var/log/audit/audit.log ]] 
 
 t_CheckExitStatus $?
+fi

--- a/tests/p_autofs/0-install_autofs.sh
+++ b/tests/p_autofs/0-install_autofs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Author: Christoph Galuschka <tigalch@tigalch.org>
 
-if [ $CONTAINERTEST -eq 1]; then
+if [ $CONTAINERTEST -eq 1 ]; then
 	    echo "Skipping this test ..."
 else
 

--- a/tests/p_autofs/0-install_autofs.sh
+++ b/tests/p_autofs/0-install_autofs.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # Author: Christoph Galuschka <tigalch@tigalch.org>
 
+if [ $CONTAINERTEST -eq 1]; then
+	    echo "Skipping this test ..."
+else
+
 t_Log "Running $0 - Installing required packages"
 
 if [ "$centos_ver" = "5" ] ; then
@@ -31,3 +35,4 @@ ls -al /mnt | egrep -q '(dnf|yum)'
 
 t_CheckExitStatus $?
 umount /mnt
+fi

--- a/tests/p_autofs/10-autofs-nfs-mount.sh
+++ b/tests/p_autofs/10-autofs-nfs-mount.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Author: Christoph Galuschka <tigalch@tigalch.org>
-
+if [  $CONTAINERTEST -eq 1]; then
+	    echo "Skipping this test ..."
+else
 t_Log "Running $0 - autofs can mount nfs share test."
 
 t_Log 'Preparing autofs configuration'
@@ -23,3 +25,4 @@ t_ServiceControl autofs stop
 t_ServiceControl nfs stop
 t_ServiceControl nfs-server stop
 t_ServiceControl rpcbind stop
+fi

--- a/tests/p_autofs/10-autofs-nfs-mount.sh
+++ b/tests/p_autofs/10-autofs-nfs-mount.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Author: Christoph Galuschka <tigalch@tigalch.org>
-if [  $CONTAINERTEST -eq 1]; then
+if [  $CONTAINERTEST -eq 1 ]; then
 	    echo "Skipping this test ..."
 else
 t_Log "Running $0 - autofs can mount nfs share test."

--- a/tests/p_bind/bind_test.sh
+++ b/tests/p_bind/bind_test.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - bind: local resolver can qualify 127.0.0.1"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 dig +timeout=1 +short @127.0.0.1 localhost | grep -q '127.0.0.1'
 
 t_CheckExitStatus $?

--- a/tests/p_bridge-utils/05-add_bridge.sh
+++ b/tests/p_bridge-utils/05-add_bridge.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Author : Madhurranjan Mohaan <madhurranjan.mohaan@gmail.com>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if  [ $# -eq 0 ]
 then
   bridge=testbridge1

--- a/tests/p_bridge-utils/10-delete_bridge.sh
+++ b/tests/p_bridge-utils/10-delete_bridge.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Author : Madhurranjan Mohaan <madhurranjan.mohaan@gmail.com>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 . "$(dirname "$0")"/p_bridge-utils-functions
 #add bridge
 bridge=testbridge2

--- a/tests/p_coreutils/0-install_coreutils.sh
+++ b/tests/p_coreutils/0-install_coreutils.sh
@@ -2,4 +2,9 @@
 # Author: Alice Kaerast <alice@kaerast.info>
 
 t_Log "$0 - installing coreutils"
-t_InstallPackage coreutils
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_InstallPackage coreutils-single
+else
+    t_InstallPackage coreutils
+fi

--- a/tests/p_curl/0-install_curl.sh
+++ b/tests/p_curl/0-install_curl.sh
@@ -3,4 +3,9 @@
 # Christoph Galuschka <christoph.galuschka@chello.at>
 
 t_Log "$0 - installing curl"
-t_InstallPackage curl
+if [ "$centos_ver" -ge "9" ]; then
+  t_InstallPackage curl-minimal
+else
+  t_InstallPackage curl
+fi
+

--- a/tests/p_dovecot/dovecot_imap_login.sh
+++ b/tests/p_dovecot/dovecot_imap_login.sh
@@ -4,6 +4,11 @@
 
 t_Log "Running $0 - adding imaptest local user account + attempting IMAP login"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 { userdel -rf imaptest; useradd imaptest && echo imaptest | passwd --stdin imaptest; } &>/dev/null
 
 # creating maildir in HOME, else test will fail at first try

--- a/tests/p_dovecot/dovecot_pop3_login.sh
+++ b/tests/p_dovecot/dovecot_pop3_login.sh
@@ -4,6 +4,11 @@
 
 t_Log "Running $0 - adding pop3test local user account + attempting POP3 login"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 { userdel -rf pop3test; useradd pop3test && echo pop3test | passwd --stdin pop3test; } &>/dev/null
 
 # creating maildir in HOME, else test will fail at first try

--- a/tests/p_file/00_file_package.sh
+++ b/tests/p_file/00_file_package.sh
@@ -2,4 +2,6 @@
 
 t_Log "Running $0 - checking if file package is installed"
 
+t_InstallPackage file
+
 t_Assert "rpm -q file"

--- a/tests/p_freeradius/10_radiusd_test.sh
+++ b/tests/p_freeradius/10_radiusd_test.sh
@@ -2,6 +2,11 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 #         Athmane Madjodj <athmanem@gmail.com>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if (t_GetPkgRel basesystem | grep -q el9)
 then
   t_Log "This is a C9 system. Freeradius doesn't work. FIX LATER. Skipping."

--- a/tests/p_httpd/0-install_httpd.sh
+++ b/tests/p_httpd/0-install_httpd.sh
@@ -8,13 +8,19 @@ then
   php_mysql="php-mysqlnd"
 fi
 
+curl="curl"
+if [ $centos_ver -ge 8 ] & [ "$CONTAINERTEST" -eq "1" ]
+then
+  curl="curl"
+fi
+
 # Install tests deps
-t_Log "Running $0 - httpd: installing curl, http, php and $php_mysql"
+t_Log "Running $0 - httpd: installing $curl, http, php and $php_mysql"
 
 #t_InstallPackage curl
 
 # HTTPD / PHP 
-t_InstallPackage curl httpd mod_ssl php $php_mysql
+t_InstallPackage $curl httpd mod_ssl php $php_mysql
 t_ServiceControl httpd stop
 sleep 3
 killall httpd

--- a/tests/p_initscripts/initscripts_service_status.sh
+++ b/tests/p_initscripts/initscripts_service_status.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - check if service cmd can get service status"
 
 # auditd is used as example because it's standard with minimal install

--- a/tests/p_iptraf/0-install_iptraf.sh
+++ b/tests/p_iptraf/0-install_iptraf.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Author: Steve Barnes (steve@echo.id.au)
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - iptraf: install iptraf and which"
 
 # IPTraf traffic monitoring package

--- a/tests/p_iptraf/5-test_iptraf.sh
+++ b/tests/p_iptraf/5-test_iptraf.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Author: Steve Barnes (steve@echo.id.au)
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - checking iptraf runs and returns non-zero exit status."
 
 TMP=/tmp/iptraf.log

--- a/tests/p_lftp/10_lftp_http_test.sh
+++ b/tests/p_lftp/10_lftp_http_test.sh
@@ -7,6 +7,11 @@
 
 t_Log "Running $0 - lftp: HTTP test"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if [ $SKIP_QA_HARNESS -eq 1 ]; then
   URL="http://mirror.centos.org/"
 else

--- a/tests/p_lftp/20_lftp_ftp.sh
+++ b/tests/p_lftp/20_lftp_ftp.sh
@@ -7,6 +7,12 @@
 
 t_Log "Running $0 - installing vsFTPd for local lftp test."
 t_InstallPackage vsftpd
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if [ "$centos_ver" -ge 8 ] ; then
 cp -fp /etc/vsftpd/vsftpd.conf /etc/vsftpd/vsftpd.conf.tf_p_lftp
 sed -i 's/anonymous_enable=NO/anonymous_enable=YES/g' /etc/vsftpd/vsftpd.conf

--- a/tests/p_libvirt/0-install_libvirt.sh
+++ b/tests/p_libvirt/0-install_libvirt.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 # Author: Athmane Madjoudj <athmanem@gmail.com>
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if (t_GetArch | grep -qE 'aarch64')
   then
   echo "Package not included with AArch64, skipping"

--- a/tests/p_libvirt/libvirt_virsh_test.sh
+++ b/tests/p_libvirt/libvirt_virsh_test.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if (t_GetArch | grep -qE 'aarch64')
   then
   echo "Package not included with AArch64, skipping"

--- a/tests/p_logwatch/logwatch_test.sh
+++ b/tests/p_logwatch/logwatch_test.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - logwatch test."
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if [ "$centos_ver" -ge 7 ] ; then
  lw_options="--range Today"
 else

--- a/tests/p_lsof/10-test_lsof.sh
+++ b/tests/p_lsof/10-test_lsof.sh
@@ -4,6 +4,11 @@
 
 t_Log "Running $0 - testing lsof against ssh port"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 sshd_status=`service sshd status | grep running`
 if ! [ "$sshd_status" ]
 then

--- a/tests/p_lynx/0-install_lynx.sh
+++ b/tests/p_lynx/0-install_lynx.sh
@@ -3,7 +3,7 @@
 
 t_Log "$0 - installing Lynx"
 
-if [ "$centos_ver" -eq "8" ]; then
+if [ "$centos_ver" -ge "8" ]; then
   t_Log "Package lynx not available in default repos on c8 => SKIP"
   exit 0
 fi

--- a/tests/p_lynx/lynx_default_page_centos_test.sh
+++ b/tests/p_lynx/lynx_default_page_centos_test.sh
@@ -3,7 +3,7 @@
 
 t_Log "Running $0 - check that lynx default page is CentOS welcome page ."
 
-if [ "$centos_ver" -eq "8" ]; then
+if [ "$centos_ver" -ge "8" ]; then
   t_Log "Package lynx not available in default repos on c8 => SKIP"
   exit 0
 fi

--- a/tests/p_lynx/lynx_dump_page_test.sh
+++ b/tests/p_lynx/lynx_dump_page_test.sh
@@ -3,7 +3,7 @@
 
 t_Log "Running $0 - check that lynx can dump remote page."
 
-if [ "$centos_ver" -eq "8" ]; then
+if [ "$centos_ver" -ge "8" ]; then
   t_Log "Package lynx not available in default repos on c8 => SKIP"
   exit 0
 fi

--- a/tests/p_mailman/0-install_mailman.sh
+++ b/tests/p_mailman/0-install_mailman.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 # Author: Athmane Madjoudj <athmanem@gmail.com>
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if (t_GetPkgRel basesystem | grep -q el9)
 then
   t_Log "This is a C9 system. mailman not present. Skipping."

--- a/tests/p_mailman/mailman_test.sh
+++ b/tests/p_mailman/mailman_test.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if (t_GetPkgRel basesystem | grep -q el9)
 then
   t_Log "This is a C9 system. mailman not present. Skipping."

--- a/tests/p_mtr/mtr_test.sh
+++ b/tests/p_mtr/mtr_test.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 TEST=mtr
 
 # Testing availability of network

--- a/tests/p_mysql/10_mysqld_conn_test.sh
+++ b/tests/p_mysql/10_mysqld_conn_test.sh
@@ -8,7 +8,7 @@ MySqlHostName=$(mysql -N -B -u root -e "show variables like 'hostname'" | cut -f
 # printing both variables for debugging purposes
 echo $HostName
 echo ${MySqlHostName}
-if [ $HostName = ${MySqlHostName} ]; then
+if [ "$HostName" = "${MySqlHostName}" ]; then
 	ret_val=0
 else
 	ret_val=1

--- a/tests/p_network/networking_vlan_test.sh
+++ b/tests/p_network/networking_vlan_test.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - create VLAN IF, assign IP on VLAN IF and tear down VLAN IF using IP command test (not on C5)"
 ret_val=0
 

--- a/tests/p_nfs/nfs_share_rw.sh
+++ b/tests/p_nfs/nfs_share_rw.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - NFS writable share test."
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 cp /etc/exports /etc/exports.orig
 echo '/srv/nfs *(rw,sync,no_root_squash)' >/etc/exports
 mkdir -p /srv/nfs

--- a/tests/p_nmap/nmap_test_eth0.sh
+++ b/tests/p_nmap/nmap_test_eth0.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - nmap querys eth0 and checks for open ssh-port"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 # Grabing IP of eth0
 IP=$(ip -f inet addr list eth0 | grep 'inet ')
 regex='.*inet\ (.*)\/.*'

--- a/tests/p_nmap/nmap_test_lo.sh
+++ b/tests/p_nmap/nmap_test_lo.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - nmap querys loopback and checks for open ssh port"
 
 nmap 127.0.0.1 | grep -qi ssh

--- a/tests/p_openssh/sshd_user_login-with-key.sh
+++ b/tests/p_openssh/sshd_user_login-with-key.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 keytypes="rsa"
 if [ "$centos_ver" -lt 8 ] ; then
 keytypes="$keytypes dsa"

--- a/tests/p_openssh/sshd_user_login.sh
+++ b/tests/p_openssh/sshd_user_login.sh
@@ -8,6 +8,11 @@ touch /home/sshtest/ssh_test_file
 
 t_Log "Running $0 - SSH Interactive user login test."
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 if [ `egrep "^PasswordAuthentication" /etc/ssh/sshd_config | tail -n1 | egrep "\syes$" | wc -l ` -gt 0 ]; then
   ./tests/p_openssh/_helper_sshd_user_login.expect | grep "ssh_test_file"  > /dev/null 2>&1
   t_CheckExitStatus $?

--- a/tests/p_postfix/10_postfix_smtp.sh
+++ b/tests/p_postfix/10_postfix_smtp.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - Postfix SMTP test."
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 echo "helo test" | nc -w 3 127.0.0.1 25 | grep -q '250'
 
 t_CheckExitStatus $?

--- a/tests/p_postfix/20_postfix_mta.sh
+++ b/tests/p_postfix/20_postfix_mta.sh
@@ -2,6 +2,12 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
 t_Log "Running $0 - postfix can accept and deliver local email."
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 ret_val=1
 
 # send mail to localhost

--- a/tests/p_postfix/30_postfix_mta_ehlo.sh
+++ b/tests/p_postfix/30_postfix_mta_ehlo.sh
@@ -2,6 +2,10 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
 t_Log "Running $0 - postfix can accept and deliver local email using ESMTP."
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
 ret_val=1
 
 # send mail to localhost

--- a/tests/p_postfix/40_postfix_sasl.sh
+++ b/tests/p_postfix/40_postfix_sasl.sh
@@ -2,6 +2,10 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
 t_Log "Running $0 - Postfix plain SASL test."
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
 t_Log "Installing prerequisits"
 
 t_InstallPackage dovecot

--- a/tests/p_postfix/50_postfix_tls.sh
+++ b/tests/p_postfix/50_postfix_tls.sh
@@ -2,6 +2,10 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
 t_Log "Running $0 - Postfix plain SASL test."
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
 t_Log "Installing prerequisits"
 
 t_InstallPackage openssl

--- a/tests/p_python-iniparse/0-install-python-iniparse.sh
+++ b/tests/p_python-iniparse/0-install-python-iniparse.sh
@@ -5,7 +5,7 @@
 t_Log "Running $0 - installing python-iniparse."
 
 if [ "$centos_ver" -ge 8 ] ; then
-t_InstallPackage python3-iniparse
+t_InstallPackage python3 python3-iniparse
 else
 t_InstallPackage python-iniparse
 fi

--- a/tests/p_samba/0-install_samba.sh
+++ b/tests/p_samba/0-install_samba.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_InstallPackage samba samba-client cifs-utils
 
 t_ServiceControl smb start

--- a/tests/p_samba/samba_share_test.sh
+++ b/tests/p_samba/samba_share_test.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - Samba share test."
 
 cp /etc/samba/smb.conf /etc/samba/smb.conf.orig

--- a/tests/p_selinux/selinux_alerts.sh
+++ b/tests/p_selinux/selinux_alerts.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - check for SELinux alerts (AVC)"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 grep -v "AVC" /var/log/audit/audit.log > /dev/null 2>&1
 
 t_CheckExitStatus $?

--- a/tests/p_selinux/selinux_policy_mismatch.sh
+++ b/tests/p_selinux/selinux_policy_mismatch.sh
@@ -8,6 +8,12 @@ fi
 
 t_Log "Running $0 - Testing audit2why for policy mismatch ..."
 
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 cat << __EOF__ | $PYTHON -
 import sys
 import selinux.audit2why as audit2why

--- a/tests/p_sendmail/10_sendmail_smtp.sh
+++ b/tests/p_sendmail/10_sendmail_smtp.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - Sendmail SMTP test."
 
 echo "helo test" | nc -4 -w 3 localhost 25 | grep -q '250'

--- a/tests/p_sendmail/20_sendmail_mta.sh
+++ b/tests/p_sendmail/20_sendmail_mta.sh
@@ -2,6 +2,10 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
 t_Log "Running $0 - sendmail can accept and deliver local email."
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
 ret_val=1
 
 # send mail to localhost

--- a/tests/p_sendmail/30_sendmail_mta_ehlo.sh
+++ b/tests/p_sendmail/30_sendmail_mta_ehlo.sh
@@ -2,6 +2,10 @@
 # Author: Christoph Galuschka <christoph.galuschka@chello.at>
 
 t_Log "Running $0 - sendmail can accept and deliver local email."
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
 ret_val=1
 
 # send mail to localhost

--- a/tests/p_shadow-utils/11-useradd_tests
+++ b/tests/p_shadow-utils/11-useradd_tests
@@ -3,6 +3,8 @@
 
 t_Log "Running $0"
 
+grep -q "^shadowuser" /etc/passwd &&  userdel -r shadowuser 
+
 # Basic useradd tests
 echo "Add user shadowuser"
 useradd shadowuser

--- a/tests/p_shadow-utils/12-usermod_tests
+++ b/tests/p_shadow-utils/12-usermod_tests
@@ -2,6 +2,7 @@
 # Author: Iain Douglas <centos@1n6.org.uk>
 
 t_Log "Running $0 - Modify user shadowuser"
+
 usermod -c "Comment plugh" shadowuser
 t_CheckExitStatus $?
 echo "Check /etc/passwd was modified" 

--- a/tests/p_shadow-utils/14-newusers_tests
+++ b/tests/p_shadow-utils/14-newusers_tests
@@ -2,6 +2,12 @@
 # Author: Iain Douglas <centos@1n6.org.uk>
 
 t_Log "Running $0 - Testing newusers"
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 grep -q "^xyssy" /etc/passwd && { t_Log "FAIL: user xyssy alredy exists"; exit $FAIL; }
 newusers <<EOF
 xyssy:plughcycle:990991:990991:xyssy comment:/home/xyssy:/bin/bash

--- a/tests/p_strace/5-test_strace.sh
+++ b/tests/p_strace/5-test_strace.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # Author: Steve Barnes (steve@echo.id.au)
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - checking strace runs and returns non-zero exit status."
 
 STRACE=`which strace`

--- a/tests/p_systemd/10-systemctl_list_services.sh
+++ b/tests/p_systemd/10-systemctl_list_services.sh
@@ -3,6 +3,12 @@
 #         Rene Diepstraten <rene@renediepstraten.nl>
 
 t_Log "Running $0 - Checking if systemctl can check if a service is enabled"
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 [ ${centos_ver} -lt 7 ] && { t_Log "Systemd is part of el since el7, skipping systemd tests..." ; exit ; }
 
 # auditd is used as example because it's standard with minimal install

--- a/tests/p_systemd/15-systemctl_list_non-native-services.sh
+++ b/tests/p_systemd/15-systemctl_list_non-native-services.sh
@@ -2,6 +2,11 @@
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 #         Rene Diepstraten <rene@renediepstraten.nl>
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 [ ${centos_ver} -lt 7 ] && exit
 t_Log "Running $0 - Checking if systemctl can check if a non-native service is enabled"
 

--- a/tests/p_systemd/20-systemctl_list-service-status.sh
+++ b/tests/p_systemd/20-systemctl_list-service-status.sh
@@ -4,6 +4,11 @@
 [ ${centos_ver} -lt 7 ] && exit
 t_Log "Running $0 - checking if systemctl can check a service status"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 systemctl is-active auditd.service > /dev/null
 
 t_CheckExitStatus $?

--- a/tests/p_systemd/25-journalctl.sh
+++ b/tests/p_systemd/25-journalctl.sh
@@ -4,6 +4,11 @@
 [ ${centos_ver} -lt 7 ] && exit
 t_Log "Running $0 - Testing journalctl for teststring"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 teststring=098f6bcd4621d373cade4e832627b4f6
 timenow=$(date +'%T')
 echo ${teststring} > /dev/kmsg

--- a/tests/p_tcpdump/02_tcpdump_lo.sh
+++ b/tests/p_tcpdump/02_tcpdump_lo.sh
@@ -4,6 +4,12 @@
 
 t_Log "Running $0 - TCPdump test to lo"
 
+
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 #Dumping pings to loopback to file
 FILE='/var/tmp/lo_test.pcap'
 COUNT='4'

--- a/tests/p_tcpdump/03_tcpdump_lo_ipv6.sh
+++ b/tests/p_tcpdump/03_tcpdump_lo_ipv6.sh
@@ -4,6 +4,11 @@
 
 t_Log "Running $0 - TCPdump test IPv6 to lo"
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 # Grabing IPv6 address of lo to check if IPv6 is enabled
 IP=$(ip addr list lo | grep 'inet6 ')
 regex='\t*inet6\ (.*)\/.*'

--- a/tests/p_vsftpd/vsftpd_anonymous_login.sh
+++ b/tests/p_vsftpd/vsftpd_anonymous_login.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - vsFTPd anonymous can login test."
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 echo -e "user anonymous\npass password\nquit" | nc localhost 21 | grep -q "230 Login successful."
 
 t_CheckExitStatus $?

--- a/tests/p_vsftpd/vsftpd_localusers_login.sh
+++ b/tests/p_vsftpd/vsftpd_localusers_login.sh
@@ -3,6 +3,11 @@
 
 t_Log "Running $0 - vsFTPd local user can login test."
 
+if [ "$CONTAINERTEST" -eq "1" ]; then
+    t_Log "Running in container -> SKIP"
+    exit 0
+fi
+
 # Add a test ftp user
 { userdel -rf ftptest; useradd ftptest && echo ftptest | passwd --stdin ftptest; } &>/dev/null
 


### PR DESCRIPTION
Works on my machine.

It is work in progress, as I want to add github actions here as well.

To run locally:

```
docker build --build-arg CONTAINERTEST=1 -f Container-8.test -t centos_stream_8_sigt_f . 
docker run -d --name test8 --privileged --rm -e CONTAINERTEST=1 -v `pwd`:/opt centos_stream_8_sigt_f
docker exec -e CONTAINERTEST=1  test8 sh -c 'cd /opt && ./runtests.sh'
```

The reason for starting the container first in daemon mode and then running the test with separate exec,
some of the tests want to see systemd as pid 1 and to have the sysctl commands available and Iconsider this a small enough workaround.