### PR TITLE
WIP: Modified runner to continue on failure.

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -45,6 +45,10 @@ if [ -e skipped-tests.list ] ;then
   done
 fi
 
+for i in successful failed skipped;do
+  test -e $i && rm $i
+done
+
 # process our test scripts
 if [ $# -gt 0 ]; then
   t_Process <(/usr/bin/find ./tests/0_*/ -type f|sort -t'/' )
@@ -64,6 +68,21 @@ if [ -e skipped-tests.list ] ;then
     reason=$(echo $line|cut -f 3 -d '|')
     t_Log " =WARNING= : Disabled test : ${test} (${reason})" 
   done
+fi
+
+if test -e successful; then 
+  t_Log "There were $(wc -l successful) tests"
+fi
+
+if test -e skipped; then 
+  t_Log "There were $(wc -l skipped) tests:"
+  cat skipped
+fi
+
+if test -e fail; then 
+  t_Log "There were $(wc -l fail) tests:"
+  cat failed
+  exit 1
 fi
 
 t_Log "QA t_functional tests finished."

--- a/t_functional_duffy_runner/src/__main__.py
+++ b/t_functional_duffy_runner/src/__main__.py
@@ -129,7 +129,7 @@ def runtests(auth_name, auth_key, query, path=None, compose=None, private_key=No
     tmux.run("cd /opt/t_functional")
     tmux.run("export SYSTEMD_PAGER=")
     tmux.run("ls -l")
-    tmux.c.run("cd /opt//t_functional && /bin/bash runtests.sh 0_common")
+    tmux.c.run("cd /opt/t_functional && /bin/bash runtests.sh")
     return tmux
 
 

--- a/tests/0_common/15_list_repos.sh
+++ b/tests/0_common/15_list_repos.sh
@@ -2,6 +2,6 @@
 
 t_Log "Running $0 - Showing the repos we have configured"
 
-yum -d0 repolist -v
+yum -d0 repollist -v
 
 t_CheckExitStatus $?

--- a/tests/p_abrt/0-install_abrt.sh
+++ b/tests/p_abrt/0-install_abrt.sh
@@ -4,7 +4,7 @@
 
 if (t_GetPkgRel basesystem | grep -q el6)
 then
-    t_InstallPackage  abrt
+    t_InstallPackage  abbbbbbrt
 else 
     echo "Skipped on CentOS 5"
 fi


### PR DESCRIPTION
The runner now collects test-scripts that failed into file `fail` and continues running other tests.
In the end, if the fail file exists, it makes the runner print the failing tests and return 1.

Work in progress, the capturing is stolen from serial-tests.sh, so there are probably worthwhile imporvements before we make this the default at least a statistic of passed/skipped/failed tests, possibly capturing and printing the output of those tests in the end, maybe even doing a proper jenkins-readable test-report.