### PR TITLE
Changed the test runner to run rest of the suite on failure

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -45,6 +45,10 @@ if [ -e skipped-tests.list ] ;then
   done
 fi
 
+for i in successful failed skipped;do
+  test -e $i && rm $i
+done
+
 # process our test scripts
 if [ $# -gt 0 ]; then
   t_Process <(/usr/bin/find ./tests/0_*/ -type f|sort -t'/' )
@@ -64,6 +68,21 @@ if [ -e skipped-tests.list ] ;then
     reason=$(echo $line|cut -f 3 -d '|')
     t_Log " =WARNING= : Disabled test : ${test} (${reason})" 
   done
+fi
+
+if test -e successful; then 
+  t_Log "There were $(wc -l successful) tests"
+fi
+
+if test -e skipped; then 
+  t_Log "There were $(wc -l skipped) tests:"
+  cat skipped
+fi
+
+if test -e fail; then 
+  t_Log "There were $(wc -l fail) tests:"
+  cat failed
+  exit 1
 fi
 
 t_Log "QA t_functional tests finished."


### PR DESCRIPTION
  There is a logic now to allow for testuite to continue running on test failure inspired by the serial-tests.sh
   
 If the testscript did run, append it's path to file 'successful'
 If it failed, append it's path to file 'failed'
 If not executable, or if it is in the same directory as previously failed test,  don't run it and add path to 'skipped'
 These three files: successful, failed and skipped are then used in the test-runner to print a statistic and fail the testsuite if there is a failure