### PR TITLE
Add AlmaLinux support

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -46,14 +46,17 @@ if [ -e skipped-tests.list ] ;then
 fi
 
 # process our test scripts
+
+t_Process <(/usr/bin/find ./tests/0_*/ -type f|sort -t'/' )
 if [ $# -gt 0 ]; then
-  t_Process <(/usr/bin/find ./tests/0_*/ -type f|sort -t'/' )
   t_Process <(/usr/bin/find ./tests/$1/ -type f|sort -t'/' )
 else
-  t_Process <(/usr/bin/find ./tests/0_*/ -type f|sort -t'/' )
   t_Process <(/usr/bin/find ./tests/p_*/ -type f|sort -t'/' )
   t_Process <(/usr/bin/find ./tests/r_*/ -type f|sort -t'/' )
-  t_Process <(/usr/bin/find ./tests/z_*/ -type f|sort -t'/' )
+  # For now we skipping these tests on AlmaLinux
+  if [[ $is_almalinux == "no" ]]; then
+    t_Process <(/usr/bin/find ./tests/z_*/ -type f|sort -t'/' )
+  fi
 fi
 
 # and, we're done.

--- a/runtests.sh
+++ b/runtests.sh
@@ -52,9 +52,11 @@ if [ $# -gt 0 ]; then
   t_Process <(/usr/bin/find ./tests/$1/ -type f|sort -t'/' )
 else
   t_Process <(/usr/bin/find ./tests/p_*/ -type f|sort -t'/' )
-  t_Process <(/usr/bin/find ./tests/r_*/ -type f|sort -t'/' )
+  if [ -z "$skip_r_tests" ]; then
+    t_Process <(/usr/bin/find ./tests/r_*/ -type f|sort -t'/' )
+  fi
   # For now we skipping these tests on AlmaLinux
-  if [[ $is_almalinux == "no" ]]; then
+  if [ -z "$skip_z_tests" ]; then
     t_Process <(/usr/bin/find ./tests/z_*/ -type f|sort -t'/' )
   fi
 fi

--- a/tests/0_common/01_dist_release_check.sh
+++ b/tests/0_common/01_dist_release_check.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Just a check to determine full version (example 5.8) or just dist (example 6)
 
-export qa_dist=$(rpm -q --queryformat '%{version}\n' centos-release)
-export qa_releasever=$(rpm -q --queryformat '%{version}.' centos-release ; rpm -q --queryformat '%{release}\n' centos-release|cut -f 1 -d '.')
+export qa_dist=$(rpm -q --queryformat '%{version}\n' $vendor-release)
+export qa_releasever=$(rpm -q --queryformat '%{version}.' $vendor-release ; rpm -q --queryformat '%{release}\n' $vendor-release|cut -f 1 -d '.')

--- a/tests/0_lib/functions.sh
+++ b/tests/0_lib/functions.sh
@@ -141,6 +141,20 @@ function t_StreamCheck
 # set stream variable
 centos_stream=$(t_StreamCheck)
 
+function t_AlmaLinuxCheck
+{
+    rpm -q almalinux-release &> /dev/null && echo "yes" || echo "no"
+}
+is_almalinux=$(t_AlmaLinuxCheck)
+
+function t_GetMinorVer
+{
+    rpm -q $(rpm -qf /etc/redhat-release) --queryformat '%{version}\n'|cut -f 2 -d '.'
+}
+
+if [[ $is_almalinux == "yes" ]]; then
+    minor_ver=$(t_GetMinorVer)
+fi
 # Description: skip test on a particular release
 # Arguments: release, reason
 function t_SkipRelease {
@@ -221,6 +235,7 @@ function t_Assert_Equals
  [ $1 -eq $2 ]
  t_CheckExitStatus $?
 }
+
 function t_Select_Alternative
 {
 	name=$1
@@ -233,6 +248,16 @@ function t_Select_Alternative
 	t_Log "Selecing alternative $option for $name--$search"
 	/bin/echo "$option"|/usr/sbin/alternatives --config "$name" >/dev/null 2>&1
 }
+
+vendor="centos"
+os_name="CentOS"
+
+if [[ $is_almalinux == "yes" ]]; then
+    export minor_ver
+    vendor="almalinux"
+    os_name="AlmaLinux"
+fi
+
 export -f t_Log
 export -f t_CheckExitStatus
 export -f t_InstallPackage
@@ -258,6 +283,10 @@ export -f t_Select_Alternative
 export centos_ver
 export centos_stream
 export arch
+export is_almalinux
+export vendor
+export os_name
+
 if [ -z "$CONTAINERTEST" ]; then
     export CONTAINERTEST=0
 fi

--- a/tests/0_lib/functions.sh
+++ b/tests/0_lib/functions.sh
@@ -249,13 +249,27 @@ function t_Select_Alternative
 	/bin/echo "$option"|/usr/sbin/alternatives --config "$name" >/dev/null 2>&1
 }
 
+if [[ "$centos_ver" -eq 8 ]] ; then
+  key_ver="201"
+elif [[ "$centos_ver" -eq 9 ]] ; then
+  key_ver="201"
+fi 
+
 vendor="centos"
 os_name="CentOS"
+grub_sb_token='CentOS Secure Boot Signing 202'
+kernel_sb_token="CentOS Secure Boot Signing 201"
+key_template="CentOS \(Linux \)\?%s signing key"
+firefox_start_page="www.centos.org"
 
 if [[ $is_almalinux == "yes" ]]; then
     export minor_ver
     vendor="almalinux"
     os_name="AlmaLinux"
+    grub_sb_token='AlmaLinux OS Foundation'
+    kernel_sb_token=$sb_signing_token
+    firefox_start_page="www.almalinux.org"
+    key_template="AlmaLinux %s signing key"
 fi
 
 export -f t_Log
@@ -286,6 +300,10 @@ export arch
 export is_almalinux
 export vendor
 export os_name
+export grub_sb_token
+export firefox_start_page
+export key_template
+export kernel_sb_token
 
 if [ -z "$CONTAINERTEST" ]; then
     export CONTAINERTEST=0

--- a/tests/0_lib/functions.sh
+++ b/tests/0_lib/functions.sh
@@ -267,7 +267,7 @@ if [[ $is_almalinux == "yes" ]]; then
     vendor="almalinux"
     os_name="AlmaLinux"
     grub_sb_token='AlmaLinux OS Foundation'
-    kernel_sb_token=$sb_signing_token
+    kernel_sb_token=$grub_sb_token
     firefox_start_page="www.almalinux.org"
     key_template="AlmaLinux %s signing key"
 fi

--- a/tests/p_centos-release/centos-release_centos-base_repos.sh
+++ b/tests/p_centos-release/centos-release_centos-base_repos.sh
@@ -4,6 +4,6 @@
 t_Log "Running $0 - CentOS Base repos sanity test."
 
 # grep "name=CentOS" /etc/yum.repos.d/CentOS*-Base*.repo >/dev/null 2>&1
-grep "name=CentOS" /etc/yum.repos.d/*.repo >/dev/null 2>&1
+grep "name=$os_name" /etc/yum.repos.d/*.repo >/dev/null 2>&1
 
 t_CheckExitStatus $?

--- a/tests/p_centos-release/centos-release_centos_gpg.sh
+++ b/tests/p_centos-release/centos-release_centos_gpg.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
-t_Log "Running $0 - CentOS RPM GPG Keys exist."
+t_Log "Running $0 - $os_name RPM GPG Keys exist."
 
-file /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS*  >/dev/null 2>&1 && \
-file /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Security*  >/dev/null 2>&1
+if [[ $is_almalinux == "yes" ]]; then
+    file /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux*  >/dev/null 2>&1
+else
+    file /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS*  >/dev/null 2>&1 && \
+    file /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Security*  >/dev/null 2>&1
+fi
 
 t_CheckExitStatus $?

--- a/tests/p_centos-release/centos-release_centos_gpg.sh
+++ b/tests/p_centos-release/centos-release_centos_gpg.sh
@@ -3,11 +3,6 @@
 
 t_Log "Running $0 - $os_name RPM GPG Keys exist."
 
-if [[ $is_almalinux == "yes" ]]; then
-    file /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux*  >/dev/null 2>&1
-else
-    file /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS*  >/dev/null 2>&1 && \
-    file /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Security*  >/dev/null 2>&1
-fi
+file "/etc/pki/rpm-gpg/RPM-GPG-KEY-$os_name*"  >/dev/null 2>&1
 
 t_CheckExitStatus $?

--- a/tests/p_centos-release/centos-release_issue.sh
+++ b/tests/p_centos-release/centos-release_issue.sh
@@ -2,6 +2,7 @@
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
 t_Log "Running $0 - /etc/issue* has correct branding"
+
 if [ "$centos_ver" -ge 7 ] ; then
   t_Log "CentOS $centos_ver -> SKIP"
   exit 0

--- a/tests/p_centos-release/centos-release_os-release.sh
+++ b/tests/p_centos-release/centos-release_os-release.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 # Author: Fabian Arrotin <arrfab@centos.org>
 
-t_Log "Running $0 - /etc/os-release has correct ABRT string for CentOS $centos_ver"
+t_Log "Running $0 - /etc/os-release has correct ABRT string for $os_name $centos_ver"
+
+if [[ $is_almalinux == "yes" ]]; then
+	lines_to_check="ALMALINUX_MANTISBT_PROJECT=\"AlmaLinux-$centos_ver\" ALMALINUX_MANTISBT_PROJECT_VERSION=\"$centos_ver.$minor_ver\""
+else
+	lines_to_check="CENTOS_MANTISBT_PROJECT=\"CentOS-$centos_ver\" CENTOS_MANTISBT_PROJECT_VERSION=\"$centos_ver\""
+fi
 
 if [ "$centos_ver" -ge 7 ];then
 	if [[ $centos_stream == "no" ]]; then
-	  for string in CENTOS_MANTISBT_PROJECT=\"CentOS-$centos_ver\" CENTOS_MANTISBT_PROJECT_VERSION=\"$centos_ver\"
+	  for string in $lines_to_check
 	  do 
 	    grep -q $string /etc/os-release
 	    if [ $? -ne "0" ];then
@@ -28,8 +34,7 @@ if [ "$centos_ver" -ge 7 ];then
 	  done  
 	fi
 else
-  echo "Skipping for CentOS 5 and 6 ..." ; exit 0
-	
+  echo "Skipping for CentOS 5 and 6 ..." ; exit 0	
 fi
 
 t_CheckExitStatus $?

--- a/tests/p_centos-release/centos-release_os-release.sh
+++ b/tests/p_centos-release/centos-release_os-release.sh
@@ -3,11 +3,7 @@
 
 t_Log "Running $0 - /etc/os-release has correct ABRT string for $os_name $centos_ver"
 
-if [[ $is_almalinux == "yes" ]]; then
-	lines_to_check="ALMALINUX_MANTISBT_PROJECT=\"AlmaLinux-$centos_ver\" ALMALINUX_MANTISBT_PROJECT_VERSION=\"$centos_ver.$minor_ver\""
-else
-	lines_to_check="CENTOS_MANTISBT_PROJECT=\"CentOS-$centos_ver\" CENTOS_MANTISBT_PROJECT_VERSION=\"$centos_ver\""
-fi
+lines_to_check="${os_name^^}_MANTISBT_PROJECT=\"$os_name-$centos_ver\" ${os_name^^}_MANTISBT_PROJECT_VERSION=\"$centos_ver.$minor_ver\""
 
 if [ "$centos_ver" -ge 7 ];then
 	if [[ $centos_stream == "no" ]]; then

--- a/tests/p_centos-release/centos-release_release_compat_symlinks.sh
+++ b/tests/p_centos-release/centos-release_release_compat_symlinks.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
-t_Log "Running $0 - /etc/centos-release compatibility symbolic links test."
+t_Log "Running $0 - /etc/$vendor-release compatibility symbolic links test."
+
 if [ "$centos_ver" -ge 6 ]
 then
-  grep "CentOS" /etc/centos-release >/dev/null 2>&1
-  (file /etc/redhat-release | grep -E "symbolic link to .?centos-release.?"  >/dev/null 2>&1) &&\
-  (file /etc/system-release | grep -E "symbolic link to .?centos-release.?"  >/dev/null 2>&1)
+  grep $os_name /etc/$vendor-release >/dev/null 2>&1
+  (file /etc/redhat-release | grep -E "symbolic link to .?$vendor-release.?"  >/dev/null 2>&1) &&\
+  (file /etc/system-release | grep -E "symbolic link to .?$vendor-release.?"  >/dev/null 2>&1)
 else
    echo "This test is not comptatible with CentOS <= 5"
 fi

--- a/tests/p_centos-release/centos-release_system_release.sh
+++ b/tests/p_centos-release/centos-release_system_release.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
-t_Log "Running $0 - /etc/centos-release has correct branding"
+t_Log "Running $0 - /etc/$vendor-release has correct branding"
 
 if [ "$centos_ver" = "5" ] ; then
     grep "CentOS" /etc/redhat-release >/dev/null 2>&1
 else
-    grep "CentOS" /etc/centos-release >/dev/null 2>&1
+    grep $os_name /etc/$vendor-release >/dev/null 2>&1
 fi
 
 t_CheckExitStatus $?

--- a/tests/p_firefox/10-check_default_startpage.sh
+++ b/tests/p_firefox/10-check_default_startpage.sh
@@ -3,17 +3,7 @@
 
 # Check for centos.org in preferences.js
 
-website="www.centos.org"
-
-if [[ $is_almalinux == "yes" ]]; then
-  if [[ $centos_ver == "8" ]]; then
-    website="www.almalinux.org"
-  elif [[ $centos_ver == "9" ]]; then
-    website="http://almalinux.org/"
-  fi
-fi
-
-t_Log "Running $0 - firefox has $website as default page."
+t_Log "Running $0 - firefox has $firefox_start_page as default page."
 
 if (t_GetArch firefox | grep -q 'x86_64')
   then
@@ -22,7 +12,7 @@ if (t_GetArch firefox | grep -q 'x86_64')
   path='/usr/lib/firefox/defaults/preferences/all-redhat.js'
 fi
 
-count=$(grep -c $website $path)
+count=$(grep -c $firefox_start_page $path)
 
 if [ $count -eq 2 ]
   then

--- a/tests/p_firefox/10-check_default_startpage.sh
+++ b/tests/p_firefox/10-check_default_startpage.sh
@@ -2,7 +2,18 @@
 # Author: Christoph Galuschka <tigalch@tigalch.org>
 
 # Check for centos.org in preferences.js
-t_Log "Running $0 - firefox has www.centos.org as default page."
+
+website="www.centos.org"
+
+if [[ $is_almalinux == "yes" ]]; then
+  if [[ $centos_ver == "8" ]]; then
+    website="www.almalinux.org"
+  elif [[ $centos_ver == "9" ]]; then
+    website="http://almalinux.org/"
+  fi
+fi
+
+t_Log "Running $0 - firefox has $website as default page."
 
 if (t_GetArch firefox | grep -q 'x86_64')
   then
@@ -11,9 +22,9 @@ if (t_GetArch firefox | grep -q 'x86_64')
   path='/usr/lib/firefox/defaults/preferences/all-redhat.js'
 fi
 
-count=$(grep -c www.centos.org $path)
+count=$(grep -c $website $path)
 
-if [ $count=2 ]
+if [ $count -eq 2 ]
   then
   t_CheckExitStatus 0
   else

--- a/tests/p_grub2/01_grub2_secureboot_signed.sh
+++ b/tests/p_grub2/01_grub2_secureboot_signed.sh
@@ -5,9 +5,15 @@ t_Log "Running $0 -  Verifying that grub2-efi is correctly signed with correct c
 
 arch=$(uname -m)
 
+signing_key='CentOS Secure Boot Signing 202'
+
+if [[ $is_almalinux == "yes" ]]; then
+  signing_key='AlmaLinux OS Foundation'
+fi
+
 if [[ "$centos_ver" -ge 7 && "$arch" = "x86_64" ]] ; then
   t_InstallPackage pesign grub2-efi-x64
-  pesign --show-signature --in /boot/efi/EFI/centos/grubx64.efi|egrep -q 'CentOS Secure Boot Signing 202'
+  pesign --show-signature --in /boot/efi/EFI/$vendor/grubx64.efi|egrep -q "$signing_key"
   t_CheckExitStatus $?
 else
   t_Log "previous versions than CentOS 7 - or not x86_64 arch - aren't using secureboot ... skipping"

--- a/tests/p_grub2/01_grub2_secureboot_signed.sh
+++ b/tests/p_grub2/01_grub2_secureboot_signed.sh
@@ -5,15 +5,10 @@ t_Log "Running $0 -  Verifying that grub2-efi is correctly signed with correct c
 
 arch=$(uname -m)
 
-signing_key='CentOS Secure Boot Signing 202'
-
-if [[ $is_almalinux == "yes" ]]; then
-  signing_key='AlmaLinux OS Foundation'
-fi
 
 if [[ "$centos_ver" -ge 7 && "$arch" = "x86_64" ]] ; then
   t_InstallPackage pesign grub2-efi-x64
-  pesign --show-signature --in /boot/efi/EFI/$vendor/grubx64.efi|egrep -q "$signing_key"
+  pesign --show-signature --in /boot/efi/EFI/$vendor/grubx64.efi|egrep -q "$grub_sb_token"
   t_CheckExitStatus $?
 else
   t_Log "previous versions than CentOS 7 - or not x86_64 arch - aren't using secureboot ... skipping"

--- a/tests/p_httpd/httpd_centos_brand_server_tokens.sh
+++ b/tests/p_httpd/httpd_centos_brand_server_tokens.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
-t_Log "Running $0 - httpd: centos branding / Server tokens value "
+t_Log "Running $0 - httpd: $os_name branding / Server tokens value "
 
-curl -sI http://localhost/ | grep -i "Server:\ Apache.*\ (CentOS" > /dev/null 2>&1
+curl -sI http://localhost/ | grep -i "Server:\ Apache.*\ ($os_name" > /dev/null 2>&1
 
 t_CheckExitStatus $?

--- a/tests/p_httpd/httpd_centos_brand_welcome.sh
+++ b/tests/p_httpd/httpd_centos_brand_welcome.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 
-t_Log "Running $0 - httpd:  Welcome page has CentOS Branding."
+t_Log "Running $0 - httpd:  Welcome page has $os_name Branding."
 
-curl -s http://localhost/ | grep 'CentOS' > /dev/null 2>&1
+curl -s http://localhost/ | grep "$os_name" > /dev/null 2>&1
 
 t_CheckExitStatus $?

--- a/tests/p_java-openjdk/p_java-openjdk-common
+++ b/tests/p_java-openjdk/p_java-openjdk-common
@@ -5,7 +5,7 @@
 [ ${centos_ver} -lt 7 ] && { t_Log "Multiple java versions test is only available since el7, skipping tests..." ; exit ; }
 
 if [ ${centos_ver} -eq 8 ];then
-JAVA_VERSIONS="1.8.0 11"
+JAVA_VERSIONS="1.8.0 11 17"
 elif [ ${centos_ver} -eq 9 ];then
 JAVA_VERSIONS="1.8.0 11 17"
 else

--- a/tests/p_kernel/01_kernel_centos_keyring.sh
+++ b/tests/p_kernel/01_kernel_centos_keyring.sh
@@ -2,7 +2,7 @@
 # Author: Athmane Madjoudj <athmanem@gmail.com>
 # Note: This was a known issue with CentOS 6.0 GA kernel
 
-t_Log "Running $0 -  check CentOS' Kernel Module GPG key."
+t_Log "Running $0 -  check $os_name Kernel Module GPG key."
 
 uname_arch=$(uname -m)
 uname_kernel=$(uname -r)
@@ -27,12 +27,19 @@ if [ "$centos_ver" -ge 7 ] ; then
   fi
   for id in kpatch "Driver update" kernel
   do
-    t_Log "Verifying x.509 CentOS ${id}"
-    keyctl list %:$ring | grep -i "CentOS \(Linux \)\?${id} signing key" > /dev/null 2>&1
+    t_Log "Verifying x.509 $os_name ${id}"
+    if [[ $is_almalinux == "yes" ]]; then
+      key="AlmaLinux ${id} signing key"
+    else
+      key="CentOS \(Linux \)\?${id} signing key"
+    fi
+    keyctl list %:$ring | grep -i "$key" > /dev/null 2>&1
     t_CheckExitStatus $?
   done
 else
-  grep 'User ID: CentOS (Kernel Module GPG key)' /var/log/dmesg > /dev/null 2>&1
+  user_id="User ID: $os_name (Kernel Module GPG key)"
+  grep "$user_id" /var/log/dmesg > /dev/null 2>&1
+
   t_CheckExitStatus $?
 fi
 

--- a/tests/p_kernel/01_kernel_centos_keyring.sh
+++ b/tests/p_kernel/01_kernel_centos_keyring.sh
@@ -28,11 +28,7 @@ if [ "$centos_ver" -ge 7 ] ; then
   for id in kpatch "Driver update" kernel
   do
     t_Log "Verifying x.509 $os_name ${id}"
-    if [[ $is_almalinux == "yes" ]]; then
-      key="AlmaLinux ${id} signing key"
-    else
-      key="CentOS \(Linux \)\?${id} signing key"
-    fi
+    key=$(printf "$key_template" "$id")
     keyctl list %:$ring | grep -i "$key" > /dev/null 2>&1
     t_CheckExitStatus $?
   done

--- a/tests/p_kernel/02_kernel_secureboot_signed.sh
+++ b/tests/p_kernel/02_kernel_secureboot_signed.sh
@@ -13,10 +13,15 @@ if [[ "$centos_ver" -ge 7 && "$arch" = "x86_64" ]] ; then
     elif [[ "$centos_ver" -eq 9 ]] ; then
       key_ver="201"
     fi 
+    if [[ $is_almalinux == "yes" ]]; then
+      key="AlmaLinux OS Foundation"
+    else
+      key="Red Hat Inc.|CentOS Secure Boot Signing $key_ver"
+    fi
     if [[ "$centos_ver" -ge 8 && "$kernel" > "4.18.0-480.el8" ]] ; then
-      pesign --show-signature --in /boot/vmlinuz-${kernel}|egrep -q "Red Hat Inc.|CentOS Secure Boot Signing $key_ver"
+      pesign --show-signature --in /boot/vmlinuz-${kernel}|egrep -q "$key"
     else 
-       pesign --show-signature --in /boot/vmlinuz-${kernel}|egrep -q 'Red Hat Inc.|CentOS Secure Boot \(key 1\)'
+      pesign --show-signature --in /boot/vmlinuz-${kernel}|egrep -q "$key"
     fi
     t_CheckExitStatus $?
   done

--- a/tests/p_kernel/02_kernel_secureboot_signed.sh
+++ b/tests/p_kernel/02_kernel_secureboot_signed.sh
@@ -8,21 +8,7 @@ if [[ "$centos_ver" -ge 7 && "$arch" = "x86_64" ]] ; then
   for kernel in $(rpm -q kernel --queryformat '%{version}-%{release}.%{arch}\n') 
     do
     t_Log "Validating kernel $kernel ..."
-    if [[ "$centos_ver" -eq 8 ]] ; then
-      key_ver="201"
-    elif [[ "$centos_ver" -eq 9 ]] ; then
-      key_ver="201"
-    fi 
-    if [[ $is_almalinux == "yes" ]]; then
-      key="AlmaLinux OS Foundation"
-    else
-      key="Red Hat Inc.|CentOS Secure Boot Signing $key_ver"
-    fi
-    if [[ "$centos_ver" -ge 8 && "$kernel" > "4.18.0-480.el8" ]] ; then
-      pesign --show-signature --in /boot/vmlinuz-${kernel}|egrep -q "$key"
-    else 
-      pesign --show-signature --in /boot/vmlinuz-${kernel}|egrep -q "$key"
-    fi
+    pesign --show-signature --in /boot/vmlinuz-${kernel}|egrep -q "$kernel_sb_token"
     t_CheckExitStatus $?
   done
 else

--- a/tests/p_lsb/lsb_release_brand_test.sh
+++ b/tests/p_lsb/lsb_release_brand_test.sh
@@ -8,9 +8,9 @@ then
   exit $PASS
 fi
 
-t_Log "Running $0 - LSB CentOS branding check."
+t_Log "Running $0 - LSB $os_name branding check."
 
-lsb_release -i | grep -q "CentOS" && \
-lsb_release -d | grep -q "CentOS"
+lsb_release -i | grep -q "$os_name" && \
+lsb_release -d | grep -q "$os_name"
 
 t_CheckExitStatus $?

--- a/tests/p_shim/01_shim_secureboot_signed.sh
+++ b/tests/p_shim/01_shim_secureboot_signed.sh
@@ -5,11 +5,11 @@ t_Log "Running $0 -  Verifying that shim.efi is correctly signed with correct ce
 
 if [[ "$centos_ver" = "7" && "$arch" = "x86_64" ]] ; then
   t_InstallPackage pesign shim
-  pesign --show-signature --in /boot/efi/EFI/centos/shim.efi|grep -q 'Microsoft Windows UEFI Driver Publisher'
+  pesign --show-signature --in /boot/efi/EFI/$vendor/shim.efi|grep -q 'Microsoft Windows UEFI Driver Publisher'
   t_CheckExitStatus $?
 elif [[ "$centos_ver" -ge "8" && "$arch" = "x86_64" ]] ; then
   t_InstallPackage pesign shim
-  pesign --show-signature --in /boot/efi/EFI/centos/shimx64.efi |grep -q 'Microsoft Windows UEFI Driver Publisher'
+  pesign --show-signature --in /boot/efi/EFI/$vendor/shimx64.efi |grep -q 'Microsoft Windows UEFI Driver Publisher'
   t_CheckExitStatus $?
 else
   t_Log "previous versions than CentOS 7 - or not x86_64 arch - aren't using shim/secureboot ... skipping"

--- a/tests/r_pdf/01_pdf-test.sh
+++ b/tests/r_pdf/01_pdf-test.sh
@@ -6,9 +6,9 @@ t_Log "Running $0 - Create PDF from postscript from text, and convert PDF back t
 if [ "$centos_ver" = "5" ] ;then
   FILE=/etc/redhat-release
 else
-  FILE=/etc/centos-release
+  FILE=/etc/$vendor-release
 fi
-FIND='CentOS'
+FIND="$os_name"
 PS_FILE=/var/tmp/test.ps
 PDF_FILE=/var/tmp/test.pdf
 TEST_FILE=/var/tmp/result


### PR DESCRIPTION
Hello!

These changes add support for AlmaLinux.

We have successfully tested it on AlmaLinux versions 8 and 9, as well as CentOS 8 Stream and CentOS 9 Stream, and can confirm that everything is working as expected.

Going forward, our plan is to continue to contribute to this project. Specifically, we aim to add more tests to ensure robustness and reliability.

Thank you for your continued support.
