### PR TITLE
Add sleep to 25-journalctl to prevent random fails

### DIFF
--- a/tests/p_systemd/25-journalctl.sh
+++ b/tests/p_systemd/25-journalctl.sh
@@ -12,6 +12,7 @@ fi
 teststring=098f6bcd4621d373cade4e832627b4f6
 timenow=$(date +'%T')
 echo ${teststring} > /dev/kmsg
+sleep 1
 journalctl --since ${timenow} | grep -q ${teststring}
 
 t_CheckExitStatus $?


### PR DESCRIPTION
The 25-journalctl test often randomly fails in the automated CentOS Stream compose testing: https://testing.stream.centos.org/job/CentOS_9-stream_ppc64le_kvm/61/console

I've done a few local runs and could reproduce it on aarch64. Adding `sleep 1` eliminated the failures for me.