### PR TITLE
p_shadow-utils: use next guid for groupadd test

### DIFF
--- a/tests/p_shadow-utils/30-groupadd_tests
+++ b/tests/p_shadow-utils/30-groupadd_tests
@@ -7,5 +7,6 @@ t_Log "Running $0 group add tests"
 sed -i /testgroup/d /etc/group
 
 echo "Create a new group"
-groupadd -g 1010 testgroup
+next_guid=$((10+$(awk -F: '{print $3}' /etc/group | sort | tail -1)))
+groupadd -g $next_guid testgroup
 t_CheckExitStatus $?

--- a/tests/p_shadow-utils/34-groupmod_tests
+++ b/tests/p_shadow-utils/34-groupmod_tests
@@ -4,8 +4,9 @@
 t_Log "Running $0"
 
 # Check that the testgroup exists with GID 1010
-grep -q "testgroup:x:1010:testshadow" /etc/group || { t_Log "FAIL Test group doesn't exist"; exit $FAIL; }
+grep -q "^testgroup:" /etc/group || { t_Log "FAIL Test group doesn't exist"; exit $FAIL; }
 
-echo "Changing GID for group testgroup to 1011"
-groupmod -g 1011 testgroup
+next_guid=$((10+$(awk -F: '{print $3}' /etc/group | sort | tail -1)))
+echo "Changing GID for group testgroup to $next_guid"
+groupmod -g $next_guid testgroup
 t_CheckExitStatus $?


### PR DESCRIPTION
There is a possibility that the guid 1010 is in used during the test and could make it fail. Picking the next available guid works around that possibility, while letting the test still test the same scenario.

It is making the test a little bit more robust to prevent failures like this one: https://testing.stream.centos.org/job/CentOS_9-stream_ppc64le_kvm/253/console