### PR TITLE
Use a python venv for tests

### DIFF
--- a/.github/workflows/centos-stream8.yml
+++ b/.github/workflows/centos-stream8.yml
@@ -22,6 +22,6 @@ jobs:
 name: Testing
 on:
  pull_request_target: 
-    branches: [ master ]
+    branches: [ '*' ]
  push: 
-    branches: [ master ]
+    branches: [ '*' ]

--- a/.github/workflows/centos-stream8.yml
+++ b/.github/workflows/centos-stream8.yml
@@ -21,7 +21,7 @@ jobs:
 
 name: Testing
 on:
- pull_request_target: 
+ pull_request: 
     branches: [ '*' ]
  push: 
     branches: [ '*' ]

--- a/.github/workflows/centos-stream8.yml
+++ b/.github/workflows/centos-stream8.yml
@@ -4,13 +4,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: centosduffy
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v4"
+      - uses: "actions/setup-python@v5"
+      - with:
+          python-version: '3.13'
+          cache: 'pip'
       - run: printf '%s\n' "$DUFFYY_SSH_PRIVATE_KEY" > /tmp/id_centos_stream
         env:
             DUFFYY_SSH_PRIVATE_KEY:  ${{ secrets.DUFFYY_SSH_PRIVATE_KEY }}
-      - run: chmod 600 /tmp/id_centos_stream
-      - run: sudo python3 -m pip install duffy fabric httpx
-      - run: python3 t_functional_duffy_runner/src/__main__.py --arch=x86 --release=centos-9s --sshkey=/tmp/id_centos_stream --path=$GITHUB_WORKSPACE
+      - run: pip install duffy fabric httpx
+
+      - run: python t_functional_duffy_runner/src/__main__.py --arch=x86 --release=centos-9s --sshkey=/tmp/id_centos_stream --path=$GITHUB_WORKSPACE
         env:
             DUFFY_AUTH_NAME: ${{ secrets.DUFFY_AUTH_NAME }}
             DUFFY_AUTH_KEY: ${{secrets.DUFFY_AUTH_KEY}}


### PR DESCRIPTION
Currently all tests are failing with:

```
python3 -m pip install duffy fabric httpx
```

and

```
Installing collected packages: pyxdg, wrapt, typing-extensions, sniffio, pycparser, invoke, h11, greenlet, decorator, annotated-types, typing-inspection, pydantic-core, httpcore, deprecated, cffi, anyio, pynacl, pydantic, httpx, paramiko, duffy, fabric
  Attempting uninstall: typing-extensions
    Found existing installation: typing_extensions 4.10.0
ERROR: Cannot uninstall typing_extensions 4.10.0, RECORD file not found. Hint: The package was installed by debian.
```

Switch to using a python virtual environment to avoid conflicts with installed packages.